### PR TITLE
animationSpeed works with an integer, but not a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Initialize
 		</script>		
 
 ### Options
-	'animationSpeed' : '250', // default for drop down animation speed
+	'animationSpeed' : 250, // default for drop down animation speed
 	'transitionOpacity': true, // default for opacity animation
 	'buttonSelector': '.menu-button', // default menu button class name
 	'hoverIntent': false, // Change to true for use with hoverIntent plugin


### PR DESCRIPTION
I tried to change the animationSpeed using animationSpeed: '500' but it doesn't work. I used animationSpeed: 500 and it works just fine. I think it's expecting the same type as 'hoverIntentTimeout'?
